### PR TITLE
Adding Indigenous Ships

### DIFF
--- a/src/endless_ships/core.clj
+++ b/src/endless_ships/core.clj
@@ -18,12 +18,12 @@
    "marauders.txt" :pirate
    "coalition ships.txt" :coalition
    "drak.txt" :drak
-   "ships.txt" :human})
+   "ships.txt" :human
+   "indigenous.txt" :indigenous})
 
 (def outfits-data
   (->> outfits
        (remove #(#{"deprecated outfits.txt"
-                   "indigenous.txt"
                    "nanobots.txt"
                    "transport missions.txt"} (:file %)))
        (map #(dissoc % :file))


### PR DESCRIPTION
Adds the indigenous.txt file to the ship/race section, and removes indigenous.txt from the "remove" section of outfits-data.

Intended to fix issue: #4 