### PR TITLE
Add the Ka'het Ship file

### DIFF
--- a/src/endless_ships/core.clj
+++ b/src/endless_ships/core.clj
@@ -14,6 +14,7 @@
    "wanderer ships.txt" :wanderer
    "quarg ships.txt" :quarg
    "remnant ships.txt" :remnant
+   "ka'het ships.txt" :ka'het
    "korath ships.txt" :korath
    "marauders.txt" :pirate
    "coalition ships.txt" :coalition


### PR DESCRIPTION
Adds the ship file for the Ka'het.

This is a new race that lives South of the Remnant in an area termed "The Graveyard." 
Added in 0.9.11