### PR TITLE
Update to v0.9.16.1

### DIFF
--- a/resources/parser.bnf
+++ b/resources/parser.bnf
@@ -11,7 +11,7 @@ data = (0-indented-block / <newline> / <comment>)+
 line = <space>? string ((<space> / <tab>) token)* <#'[ \t]*#.*'>? <newline>
 
 <token> = string | number
-string = #'[a-zA-Z0-9=?\(\)><*/+\-\'_]+' | <'"'> #'[^"]*' <'"'> | <'`'> #'[^`]*' <'`'>
+string = #'[a-zA-Z0-9=?\(\)><*/+\-\'_!]+' | <'"'> #'[^"]*' <'"'> | <'`'> #'[^`]*' <'`'>
 space = #'[, ]+'
 tab = '\t'
 newline = #'[ \t]*\n'

--- a/src/clj/endless_ships/core.clj
+++ b/src/clj/endless_ships/core.clj
@@ -14,10 +14,12 @@
    "quarg ships.txt" :quarg
    "remnant ships.txt" :remnant
    "ka'het ships.txt" :ka'het
+   "kahet ships.txt" :ka'het
    "korath ships.txt" :korath
    "marauders.txt" :pirate
    "coalition ships.txt" :coalition
    "drak.txt" :drak
+   "drak ships.txt" :drak
    "ships.txt" :human
    "indigenous.txt" :indigenous
    "sheragi ships.txt" :sheragi})

--- a/src/clj/endless_ships/outfits.clj
+++ b/src/clj/endless_ships/outfits.clj
@@ -137,7 +137,8 @@
   (->> data
        (filter (fn [[type [name]]]
                  (and (= type "outfit")
-                      (not (str/starts-with? name "_")))))
+                      (not (str/starts-with? name "_"))
+                      (not (contains? #{"Imaginary Weapon" "Timer Weapon" "Mouthparts?"} name)))))
        (map (fn [[_
                   [name]
                   {description-attrs "description"

--- a/src/clj/endless_ships/parser.clj
+++ b/src/clj/endless_ships/parser.clj
@@ -48,7 +48,7 @@
    (->> files
         (mapcat (fn [file]
                   (let [filename (.getName file)
-                        objects (-> file slurp parse)]
+                        objects (-> file slurp (str "\n") parse)]
                     (map #(assoc-in % [2 "file"] filename) objects))))
         doall)))
 

--- a/src/cljs/endless_ships/utils/outfits.cljs
+++ b/src/cljs/endless_ships/utils/outfits.cljs
@@ -25,8 +25,9 @@
                                              "Turn. energy"   {:value :turning-energy}
                                              "Turn. heat"     {:value :turning-heat})}
              :reactors {:header "Reactors"
-                        :filter #(or (contains? % :energy-generation)
-                                     (contains? % :solar-collection))
+                        :filter #(and (or (contains? % :energy-generation)
+                                          (contains? % :solar-collection))
+                                      (= (:category %) "Power"))
                         :initial-ordering {:column-name "Energy per space"
                                            :order :desc}
                         :columns (let [energy-generation #(+ (get % :energy-generation 0)


### PR DESCRIPTION
This was my first encounter with any Lisp language, so I'm sure my code there could be improved.

Additionally, while testing this I noticed the following gaps/issues that I wasn't Lisp-proficient enough to fix:
- Firelight missile bank stats don't work, because it's got a weird two-stage projectile and the following in `src/clj/endless-ships/outfits.clj` only traverses one stage:
```clojure
                      :weapon (-> weapon-attrs
                                  (get-in [0 1])
                                  ->map
                                  (assoc :submunition (get-in weapon-attrs [0 1 "submunition" 0 0])))
```
- Langrage Hyper-Heaver stats are messed up, although it's a complicated weapon so not sure it's worth fixing.

I also was hoping to do the following, but couldn't figure out how to do it:
- Label outfits by race (pass the data subdirectory along when collecting data files?)
- Label outfits by whether they can be purchased (may require inversion or re-processing with the outfitters output, currently only done on the frontend)

(this was split from https://github.com/7even/endless-ships/pull/12)