### PR TITLE
Add afterburner outfit table and antimissile "rate" column

### DIFF
--- a/src/cljs/endless_ships/utils/outfits.cljs
+++ b/src/cljs/endless_ships/utils/outfits.cljs
@@ -24,6 +24,19 @@
                                                                           (:outfit-space %))}
                                              "Turn. energy"   {:value :turning-energy}
                                              "Turn. heat"     {:value :turning-heat})}
+             :afterburners {:header "Afterburners"
+                         :filter #(contains? % :afterburner-thrust)
+                         :initial-ordering {:column-name "Thrust per space"
+                                            :order :desc}
+                         :columns (array-map "Outfit sp."       {:value :outfit-space}
+                                             "Thrust"           {:value :afterburner-thrust}
+                                             "Thrust per space" {:value #(/ (:afterburner-thrust %)
+                                                                            (:outfit-space %))}
+                                             "Thr. fuel"        {:value :afterburner-fuel}
+                                             "Thrust per fuel"  {:value #(/ (:afterburner-thrust %)
+                                                                            (:afterburner-fuel %))}
+                                             "Thr. energy"      {:value :afterburner-energy}
+                                             "Thr. heat"        {:value :afterburner-heat})}
              :reactors {:header "Reactors"
                         :filter #(or (contains? % :energy-generation)
                                      (contains? % :solar-collection))

--- a/src/cljs/endless_ships/utils/outfits.cljs
+++ b/src/cljs/endless_ships/utils/outfits.cljs
@@ -144,13 +144,17 @@
                                                                     :orderable? false})}
              :anti-missile {:header "Anti-missile turrets"
                             :filter #(-> % :weapon (contains? :anti-missile))
-                            :initial-ordering {:column-name "Anti-missile"
+                            :initial-ordering {:column-name "Anti-missile rate"
                                                :order :desc}
-                            :columns (array-map "Outfit sp."   {:value :outfit-space}
-                                                "Anti-missile" {:value #(get-in % [:weapon :anti-missile])}
-                                                "Range"        {:value #(get-in % [:weapon :range])}
-                                                "Fire rate"    {:value #(get-in % [:weapon :shots-per-second])
-                                                                :orderable? false})}
+                            :columns (array-map "Outfit sp."        {:value :outfit-space}
+                                                "Anti-missile rate" {:value #(if (= (get-in % [:weapon :shots-per-second]) "continuous")
+                                                                                 (/ 1 0)
+                                                                                 (* (get-in % [:weapon :anti-missile])
+                                                                                    (get-in % [:weapon :shots-per-second])))}
+                                                "Anti-missile"      {:value #(get-in % [:weapon :anti-missile])}
+                                                "Range"             {:value #(get-in % [:weapon :range])}
+                                                "Fire rate"         {:value #(get-in % [:weapon :shots-per-second])
+                                                                     :orderable? false})}
              :hand-to-hand {:header "Hand to Hand"
                             :filter #(= (:category %) "Hand to Hand")
                             :initial-ordering {:column-name "Capture attack"


### PR DESCRIPTION
Afterburner is pretty self-explanatory, see preview:
![image](https://user-images.githubusercontent.com/1059977/200148934-266d36ce-faa4-4e2a-ba3f-8479697ca1ff.png)

New anti-missile column and sorting (multiplies fire rate and antimissile strength, which captures the overall rate of shredding missiles):
![image](https://user-images.githubusercontent.com/1059977/200148951-507649d8-d87f-4ea3-ab51-28b23514c60e.png)

(this was split from https://github.com/7even/endless-ships/pull/12)