### PR TITLE
Dockerfile: Specify fully qualified image name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Prepare the boot build image and dependencies
-FROM clojure:temurin-21-alpine AS build
+FROM docker.io/clojure:temurin-21-alpine AS build
 RUN apk add --update git npm
 RUN npm install -g yarn shadow-cljs
 
@@ -16,7 +16,7 @@ RUN cd resources/game \
 RUN clojure -J-Xmx8g -X:clj:build
 
 # Copy build results to the final image
-FROM nginx:alpine
+FROM docker.io/nginx:alpine
 COPY --from=build /app/build /usr/share/nginx/html
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
 


### PR DESCRIPTION
Why:
podman and containerd require fully qualified names for Docker images, meaning that the hostname of the registry needs to be present. Docker defaults to docker.io when that is missing, but both podman and containerd require specific configuration for that to happen on the part of the operator.

What:
Make life easier for users of alternate container engines by specifying the fully qualified names for images in the Dockerfile