### PR TITLE
Add some VSCode and Github Codespaces configuration files

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,26 @@
+FROM docker.io/clojure:temurin-21-tools-deps-bookworm
+
+RUN apt-get update && \
+    apt-get install -y git rlwrap npm
+
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Create the user
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME --shell /bin/bash \
+    #
+    # [Optional] Add sudo support. Omit if you don't need to install software after connecting.
+    && apt-get update \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# ********************************************************
+# * Anything else you want to do like clean up goes here *
+# ********************************************************
+
+# [Optional] Set the default user. Omit if you want to keep the default as root.
+USER $USERNAME
+ENTRYPOINT ["/bin/bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+	"name": "endless-ships",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+
+	"features": {},
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode":{
+			"extensions": [
+				"betterthantomorrow.calva"
+			]
+		}
+	}
+	/*
+  // unprivileged podman trick, comment if you want to use Docker. Also amend
+  // uid/gid if these don't match yours
+	,"runArgs": [
+		"--userns=keep-id:uid=1000,gid=1000"
+	],
+	"containerUser": "vscode",
+	"updateRemoteUserUID": true,
+	"containerEnv": {
+		"HOME": "/home/vscode"
+	}
+	*/
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ data.edn
 /public/js
 /node_modules
 /.cpcache
+# Calva related
+/.clj-kondo/.cache
+/.lsp/.cache
+/.calva/output-window


### PR DESCRIPTION
Why:
    Using devcontainers for development in IDEs like VSCode or even remote
    environments like Github Codespaces is an emerging paradigm. One of the
    biggest supposed benefits is reproducibility of the development
    environment, hopefully negating the dreated "it works on my machine!"
    
What:
    Add a simple hierarchy of files to help future development
    efforts in such IDEs or remote environments
    
    A couple of notes:
 
    * This builds upon docker.io/clojure:temurin-21-tools-deps-bookworm for
      now, as this the linux Distro, I mostly feel comfortable with. The
      intent is to align this with the image in the main Dockerfile, namely
      docker.io/clojure:temurin-21-alpine
    * It installs Calva by default, which is the Clojure enabling addon for
      VSCode. While it works very well in VSCode, I am meeting some issues
      with the REPL functionality in Github Codespaces.
    * Unprivileged podman is possible, but commented out for now by default,
      as I am still evaluating how well it works with Github Codespaces.
