### PR TITLE
Appease clj-kondo as a linting tool

### DIFF
--- a/src/clj/endless_ships/core.clj
+++ b/src/clj/endless_ships/core.clj
@@ -134,7 +134,7 @@
              (io/file "./build/app.css"))
     (io/copy (io/file "./public/ga.json")
              (io/file "./build/ga.json"))
-    (if (.exists (io/file "./ga.json"))
+    (when (.exists (io/file "./ga.json"))
       (io/copy (io/file "./ga.json")
                (io/file "./build/ga.json")))))
 

--- a/src/clj/endless_ships/core.clj
+++ b/src/clj/endless_ships/core.clj
@@ -8,7 +8,8 @@
             [clojure.string :as str]
             [endless-ships.outfits :refer [outfits]]
             [endless-ships.outfitters :refer [outfitters]]
-            [endless-ships.ships :refer [modifications ships]]))
+            [endless-ships.ships :refer [modifications ships]]
+            [endless-ships.parser]))
 
 (def file->race
   {"kestrel.txt" :human

--- a/src/clj/endless_ships/outfits.clj
+++ b/src/clj/endless_ships/outfits.clj
@@ -1,6 +1,7 @@
 (ns endless-ships.outfits
   (:require [clojure.string :as str]
-            [endless-ships.parser :refer [->map data]]))
+            [endless-ships.parser :refer [->map data]])
+  (:import [java.lang Integer]))
 
 (defn- update-if-present [m k f]
   (if (contains? m k)

--- a/src/clj/endless_ships/outfits.clj
+++ b/src/clj/endless_ships/outfits.clj
@@ -92,7 +92,7 @@
 (defn- normalize-weapon-attrs [outfits]
   (map
    (fn [{category :category
-         {:keys [reload velocity velocity-override lifetime shield-damage hull-damage]
+         {:keys [reload velocity velocity-override lifetime] ; shield-damage hull-damage]
           [submunition-name submunition-count] :submunition
           :as weapon-attrs} :weapon
          :as outfit}]

--- a/src/clj/endless_ships/outfitters.clj
+++ b/src/clj/endless_ships/outfitters.clj
@@ -1,5 +1,5 @@
 (ns endless-ships.outfitters
-  (:require [endless-ships.parser :refer [->map data]]))
+  (:require [endless-ships.parser :refer [data]]))
 
 (defn- find-object-with-name [objects name]
   (some (fn [object]

--- a/src/clj/endless_ships/parser.clj
+++ b/src/clj/endless_ships/parser.clj
@@ -3,7 +3,7 @@
             [clojure.java.io :refer [file resource]]
             [clojure.string :as str]
             [instaparse.core :as insta])
-  (:import [java.lang Float Integer]))
+  (:import [java.lang Float]))
 
 (def files
   "All files containing game data."

--- a/src/clj/endless_ships/ships.clj
+++ b/src/clj/endless_ships/ships.clj
@@ -1,6 +1,5 @@
 (ns endless-ships.ships
-  (:require [clojure.set :refer [rename-keys]]
-            [endless-ships.parser :refer [->map data]]))
+  (:require [endless-ships.parser :refer [->map data]]))
 
 (defn- add-key-if [cond key value]
   (if cond

--- a/src/clj/endless_ships/ships.clj
+++ b/src/clj/endless_ships/ships.clj
@@ -27,7 +27,8 @@
           :file file}
          (add-key-if (contains? ship "sprite")
                      :sprite
-                     [sprite (not (empty? animation))])
+                     [sprite #_{:clj-kondo/ignore [:not-empty?]}
+                             (not (empty? animation))])
          (add-key-if (contains? attrs "licenses")
                      :licenses
                      (-> license-attrs keys vec))


### PR DESCRIPTION
As I am familiarizing myself more with the codebase, I can't help but see the various clj-kondo warnings. This is a series of commits that mostly appease clj-kondo. Note that I haven't touch the clojurescript part of the codebase at all, I am utterly unfamiliar with Clojurescript yet. If this is deemed OK and wanted, I can look also look into adding Github Action based linting on e.g. PRs